### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/ticket-vision/duratypes/security/code-scanning/4](https://github.com/ticket-vision/duratypes/security/code-scanning/4)

To fix the problem, add a `permissions` block to the `security` job in `.github/workflows/ci.yml` that restricts the GITHUB_TOKEN to the minimum required privileges. Since the `security` job only needs to check out code and upload an artifact, it only requires read access to repository contents. Therefore, add `permissions: { contents: read }` at the same indentation level as `runs-on` within the `security` job. No other changes or imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
