### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Build & Publish to TestPyPI and PyPI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ticket-vision/duratypes/security/code-scanning/7](https://github.com/ticket-vision/duratypes/security/code-scanning/7)

To fix the problem, you should add a `permissions` block to the workflow, either at the root level (to apply to all jobs) or to each job individually. The block should specify the minimal permissions required for the workflow to function. For publishing to PyPI/TestPyPI and uploading artifacts, the jobs typically only need `contents: read` (to read the repository contents) and possibly `id-token: write` if OIDC authentication is used (not shown here). Since the workflow does not interact with issues, pull requests, or other resources, those permissions can be omitted. The best fix is to add a root-level `permissions` block with `contents: read`, which will apply to all jobs unless overridden. This should be inserted after the `name:` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
